### PR TITLE
Report correct stats for windows containers

### DIFF
--- a/cmd/ctr/commands/tasks/metrics.go
+++ b/cmd/ctr/commands/tasks/metrics.go
@@ -176,7 +176,7 @@ func printWindowsContainerStatistics(w *tabwriter.Writer, stats *wstats.WindowsC
 	if stats.Processor != nil {
 		fmt.Fprintf(w, "cpu.total_runtime_ns\t%d\t\n", stats.Processor.TotalRuntimeNS)
 		fmt.Fprintf(w, "cpu.runtime_user_ns\t%d\t\n", stats.Processor.RuntimeUserNS)
-		fmt.Fprintf(w, "cpu.runtime_kernel_ns\t%d\t\n", stats.Processor.RuntimeUserNS)
+		fmt.Fprintf(w, "cpu.runtime_kernel_ns\t%d\t\n", stats.Processor.RuntimeKernelNS)
 	}
 	if stats.Memory != nil {
 		fmt.Fprintf(w, "memory.commit_bytes\t%d\t\n", stats.Memory.MemoryUsageCommitBytes)


### PR DESCRIPTION
Windows container stats were reporting incorrect metrics for cpu kernel runtime.